### PR TITLE
Fix Backslash in #include

### DIFF
--- a/src/gpe/gpe_animation2d.h
+++ b/src/gpe/gpe_animation2d.h
@@ -43,7 +43,7 @@ SOFTWARE.
 #include "gpe_branch.h"
 #include "gpe_renderer_base.h"
 #include "gpe_texture_base.h"
-#include "internal_libs\stg_ex.h"
+#include "internal_libs/stg_ex.h"
 
 namespace gpe
 {


### PR DESCRIPTION
Needed for Linux and other Unix-likes.