### PR TITLE
Fix FreeBSD build.

### DIFF
--- a/src/pawgui/pawgui_dock_system.cpp
+++ b/src/pawgui/pawgui_dock_system.cpp
@@ -542,12 +542,12 @@ namespace pawgui
                 if( panelId < panel_x_count )
                 {
                     panel_height_percentages[panelId ] = 100.f;
-                    panel_height_percentages[panelId + panel_x_count ] = 0.0d;
+                    panel_height_percentages[panelId + panel_x_count ] = 0.0;
                 }
                 else
                 {
                     panel_height_percentages[panelId ] = 100.f;
-                    panel_height_percentages[panelId - panel_x_count ] = 0.0d;
+                    panel_height_percentages[panelId - panel_x_count ] = 0.0;
                 }
             }
             else if( panel_height_percentages[panelId ] <= dock_minimum_row_percentage )
@@ -817,7 +817,7 @@ namespace pawgui
                                     panel_resize_difference = ( gpe::input->mouse_position_x - currentpanel_x );
 
                                     //Panel resizing only is between two panels, so let's calculate the differences;
-                                    panel_resize_difference = (float)panel_resize_difference / (  dock_width_minus_column_padding / 100.00000d);
+                                    panel_resize_difference = (float)panel_resize_difference / (  dock_width_minus_column_padding / 100.00000);
                                     if( panel_resize_difference >= 0.0001 )
                                     {
                                         panel_width_percentage[ column_being_resized_id ] -=  panel_resize_difference;

--- a/src/sdl2_module/gpe_font_sdl2.cpp
+++ b/src/sdl2_module/gpe_font_sdl2.cpp
@@ -170,8 +170,7 @@ namespace gpe
             characterPairs[")" ] = new font_pair_sdl2(heldSDLFont,")" );
             if( make_monospaced == false)
             {
-                std::map<std::string,font_pair_sdl2 *>::iterator foundIterator;
-                foundIterator = characterPairs.find("9");
+                auto foundIterator = characterPairs.find("9");
                 if( foundIterator!= characterPairs.end() )
                 {
                     font_pair_sdl2 * tempfont_pair_sdl2 = foundIterator->second;
@@ -209,7 +208,7 @@ namespace gpe
         }
         clear_cache();
         font_pair_sdl2 * tempfont_pair_sdl2 = NULL;
-        for (std::map<std::string,font_pair_sdl2 *>::iterator it=characterPairs.begin(); it!=characterPairs.end(); ++it)
+        for (auto it=characterPairs.begin(); it!=characterPairs.end(); ++it)
         {
             tempfont_pair_sdl2 = it->second;
             if( tempfont_pair_sdl2!=NULL)
@@ -225,7 +224,7 @@ namespace gpe
     void font_sdl2_tff::clear_cache()
     {
         font_pair_sdl2 * tempfont_pair_sdl2 = NULL;
-        for (std::map<std::string,font_pair_sdl2 *>::iterator it=textPairs.begin(); it!=textPairs.end(); ++it)
+        for (auto it=textPairs.begin(); it!=textPairs.end(); ++it)
         {
             tempfont_pair_sdl2 = it->second;
             if( tempfont_pair_sdl2!=NULL)
@@ -332,8 +331,7 @@ namespace gpe
     {
         font_pair_sdl2 * fPair = NULL;
         SDL_Texture * fSDLTexture = NULL;
-        std::map<std::string,font_pair_sdl2 *>::iterator foundVal;
-        foundVal = characterPairs.find( id_number );
+        auto foundVal = characterPairs.find( id_number );
         if( foundVal !=  characterPairs.end() )
         {
             fPair = foundVal->second;


### PR DESCRIPTION
Please make sure this doesn't break Windows first by testing before you merge.

The compile errors I had were due to code used that wasn't compatible with FreeBSD's clang compiler, (clang is shipped with FreeBSD's base and therefore is preferred over gcc).

At least it compiles OK now. I'm getting these errors trying to run it: [game_errors.txt](https://github.com/pawbyte/Game-Pencil-Engine-Editor/files/15505723/game_errors.txt)
